### PR TITLE
Increase FlexRAN pod wait time to be ready

### DIFF
--- a/ocp/dci-openshift-app-agents/roles/test-timer/tasks/run_test.yml
+++ b/ocp/dci-openshift-app-agents/roles/test-timer/tasks/run_test.yml
@@ -31,7 +31,7 @@
     name: flexran-du
   register: flexran_pod
   retries: 60
-  delay: 5
+  delay: 10
   until:
     - "flexran_pod.resources|length >=1"
     - "'status' in flexran_pod.resources[0]"


### PR DESCRIPTION
In latest CI job runs the `flexran-du` pod didn't start within the current 5 minute wait time(took ~6minutes). This change increases the wait time to 10 minutes to give it enough time for the pod to start. 


```
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-10-02T23:11:52Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-10-02T23:17:53Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-10-02T23:17:53Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-10-02T23:11:52Z"
    status: "True"
    type: PodScheduled
```