### PR TITLE
Use dynamic vfio token introduced in SRIOV-FEC 2.7.0

### DIFF
--- a/ocp/dci-openshift-app-agents/hosts.yml
+++ b/ocp/dci-openshift-app-agents/hosts.yml
@@ -19,6 +19,7 @@ all:
     timercfgs:
       - clxsp_mu0_20mhz_4x4_hton.cfg
     secure_boot: false
+    secure_boot_static_token: false
     fec_use_subscription: false 
     fec_index_url: "quay.io/intel-operator/n3000-operators-index@sha256:3f27e4a7bfbd238f39212b4f766c0ac3d525ede916b283b67a92788a2fba7872"
     registry_secrets:

--- a/ocp/dci-openshift-app-agents/roles/lib/scripts/pod/read_yaml_write_xml.py
+++ b/ocp/dci-openshift-app-agents/roles/lib/scripts/pod/read_yaml_write_xml.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 import lxml.etree as LET
 from dataclasses import dataclass, field
 from cpu import CpuResource
+import json
 
 #function to read env variable
 def get_env_variable(evn_variable_name: str) -> str:
@@ -403,7 +404,13 @@ class CfgData:
                             xml_dpdk_device.text = dpdk.base_band_device_val
 
                         xml_vfio_token = root_dpdks.find("dpdkVfioVfToken")
-                        vfio_token = get_env_variable("VFIO_TOKEN")
+
+                        if get_env_variable("VFIO_TOKEN"):
+                            vfio_token = get_env_variable("VFIO_TOKEN")
+                        else:
+                            for acc_info in json.loads(get_env_variable("PCIDEVICE_INTEL_COM_INTEL_FEC_ACC100_INFO")).values():
+                               vfio_token = acc_info['extra']['VFIO_TOKEN']
+
                         if xml_vfio_token is not None and vfio_token is not None:
                            xml_vfio_token.text = vfio_token
 

--- a/ocp/dci-openshift-app-agents/roles/test-timer/templates/pod_flexran_timer.yml
+++ b/ocp/dci-openshift-app-agents/roles/test-timer/templates/pod_flexran_timer.yml
@@ -9,7 +9,7 @@ spec:
     - name: flexran-du
       image: {{ flexran_image | default(ansible_default_ipv4.address+':5000/flexran:'+flexran_version|string) }}
       imagePullPolicy: Always
-{% if secure_boot %}
+{% if secure_boot_static_token %}
       env:
       - name: VFIO_TOKEN
         valueFrom:


### PR DESCRIPTION
In SRIOV-FEC 2.7.0 it was introduced a dynamic token feature that can be used with secure boot environments. This can be retrieved from PCIDEVICE_INTEL_COM_INTEL_FEC_ACC100_INFO environment variable instead of static secret e.g:

```
PCIDEVICE_INTEL_COM_INTEL_FEC_ACC100_INFO={"0000:62:01.5":{"extra": {"VFIO_TOKEN":"02bddbbf-bbb0-4d79-886b-91bad3fbb510"},"generic": {"deviceID":"0000:62:01.5"},"vfio":{"dev-mount":"/dev/vfio/110", "mount":"/dev/vfio/vfio"}}}
```